### PR TITLE
Update Go version to 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.1'
+          go-version: '1.22'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:
           distribution: goreleaser
-          version: ${{ env.GITHUB_REF_NAME }}
+          version: latest
           args: release --clean
           workdir: ./
         env:


### PR DESCRIPTION
This pull request updates the Go version from 1.21.1 to 1.22. It also updates the version in the GoReleaser action to "latest" for a cleaner release.